### PR TITLE
feat: 사진 찍은 후, 진단결과에 전달

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     //카카오 로그인
     implementation "com.kakao.sdk:v2-user:2.18.0"
 
+    //Glide
+    implementation 'com.github.bumptech.glide:glide:4.12.0'
+
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/app/src/main/java/com/konkuk/nongboohae/presentation/diagnosis/DiagnosisBottomSheet.kt
+++ b/app/src/main/java/com/konkuk/nongboohae/presentation/diagnosis/DiagnosisBottomSheet.kt
@@ -127,10 +127,11 @@ class DiagnosisBottomSheet : BottomSheetDialogFragment() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == REQUEST_TAKE_PHOTO && resultCode == AppCompatActivity.RESULT_OK) {
-            Log.d("ImageURI", getPhotoURI.toString()) // 이미지 URI 획득!!
+            Log.d("photoUri", getPhotoURI.toString()) // 이미지 URI 획득!!
             // 서버통신 구현 필요
             // 모델로부터 값을 받아오면 진단 결과화면으로 전환
             val intent = Intent(requireActivity(), DiagnosisResultActivity::class.java)
+            intent.putExtra("photoUri", getPhotoURI.toString())
             startActivity(intent)
             dismiss()
         }

--- a/app/src/main/java/com/konkuk/nongboohae/presentation/diagnosis/DiagnosisResultActivity.kt
+++ b/app/src/main/java/com/konkuk/nongboohae/presentation/diagnosis/DiagnosisResultActivity.kt
@@ -3,6 +3,7 @@ package com.konkuk.nongboohae.presentation.diagnosis
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import com.bumptech.glide.Glide
 import com.konkuk.nongboohae.R
 import com.konkuk.nongboohae.databinding.ActivityDiagnosisResultBinding
 import com.konkuk.nongboohae.presentation.base.BaseActivity
@@ -19,6 +20,10 @@ class DiagnosisResultActivity : BaseActivity<ActivityDiagnosisResultBinding>() {
     }
 
     override fun afterViewCreated() {
+        val photoUri = intent.getStringExtra("photoUri")
+        Glide.with(this)
+            .load(photoUri)
+            .into(binding.diagnosisResultPhotoIv)
         initClickListener()
     }
 

--- a/app/src/main/res/layout/activity_diagnosis_result.xml
+++ b/app/src/main/res/layout/activity_diagnosis_result.xml
@@ -68,6 +68,7 @@
                 android:id="@+id/diagnosis_result_photo_iv"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:scaleType="centerCrop"
                 android:src="@color/cardview_shadow_start_color" />
 
         </androidx.cardview.widget.CardView>


### PR DESCRIPTION
## 개요
-  기존에는 찍은 사진이 진단 결과 화면에 전달되지 않았는데, 전달되게 수정하였습니다.

## 작업사항
- Glide 라이브러리 종속성 추가
- 이미지 전달 후 띄우기

## 논의사항
- 이미지를 보여줄 때 어떤 방식으로 보여줄 지 고민했습니다.

- 사진이 세로로 찍히는데, scaleType을 지정해주지 않으니까 현재 설정되어 있는 사이즈에 맞추기 위해 사진이 매우 작아지는 현상이 있었습니다. 따라서 이를 해결하려면
1) 세로 사이즈를 wrap_content로 하여 사진을 원본비율로 다 담아주는 방법
2) scaleType을 centerCrop으로 하여 사진은 좀 잘리되, 현재 디자인을 최대한 유지

- 두가지 방법이 있었는데, 1)은 너무 사진이 차지하는 비중이 커질 것 같아 안 좋은 것 같고, 2)를 적용하되 클릭시 사진을 전체화면으로 보여줄 수 있게 하는 방향이 좋을 것 같습니다!