### PR TITLE
feat: 바텀네비게이션 아이콘 클릭 이벤트 추가

### DIFF
--- a/app/src/main/java/com/konkuk/nongboohae/presentation/base/BaseActivity.kt
+++ b/app/src/main/java/com/konkuk/nongboohae/presentation/base/BaseActivity.kt
@@ -6,6 +6,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.konkuk.nongboohae.util.factory.ViewModelFactory
@@ -45,6 +46,10 @@ abstract class BaseActivity<T : ViewDataBinding> : AppCompatActivity() {
         toast?.cancel()
         toast = Toast.makeText(this, msg, Toast.LENGTH_SHORT)
         toast?.show()
+    }
+
+    fun setFragment(id: Int, fragment: Fragment) {
+        supportFragmentManager.beginTransaction().replace(id, fragment).commit()
     }
 
 }

--- a/app/src/main/java/com/konkuk/nongboohae/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/konkuk/nongboohae/presentation/main/MainActivity.kt
@@ -16,6 +16,7 @@ import com.konkuk.nongboohae.R
 import com.konkuk.nongboohae.databinding.ActivityMainBinding
 import com.konkuk.nongboohae.presentation.base.BaseActivity
 import com.konkuk.nongboohae.presentation.diagnosis.DiagnosisBottomSheet
+import com.konkuk.nongboohae.presentation.main.search.SearchFragment
 import java.io.File
 import java.io.IOException
 import java.text.SimpleDateFormat
@@ -27,7 +28,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
     override val layoutRes: Int = R.layout.activity_main
 
     override fun initViewModel() {
-
+        setBottomNavi()
     }
 
     override fun afterViewCreated() {
@@ -35,6 +36,35 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
             val modal = DiagnosisBottomSheet()
             modal.setStyle(DialogFragment.STYLE_NORMAL, R.style.TransParentBottomSheetDialogTheme)
             modal.show(supportFragmentManager, DiagnosisBottomSheet.TAG)
+        }
+    }
+
+
+    private fun setBottomNavi() {
+        binding.btnv.setOnItemSelectedListener { item ->
+            when (item.itemId) {
+                R.id.HistoryFragment -> {
+                    setFragment(R.id.nav_host_fragment, SearchFragment())
+                    Log.d("Stack-Log", "HistoryFragment()")
+                    return@setOnItemSelectedListener true
+                }
+                R.id.CommunityFragment -> {
+                    setFragment(R.id.nav_host_fragment, SearchFragment())
+                    Log.d("Stack-Log", "SearchFragment()")
+                    return@setOnItemSelectedListener true
+                }
+                R.id.SearchFragment -> {
+                    setFragment(R.id.nav_host_fragment, SearchFragment())
+                    Log.d("Stack-Log", "SearchFragment()")
+                    return@setOnItemSelectedListener true
+                }
+                R.id.MyPageFragment -> {
+                    setFragment(R.id.nav_host_fragment, SearchFragment())
+                    Log.d("Stack-Log", "SearchFragment()")
+                    return@setOnItemSelectedListener true
+                }
+            }
+            false
         }
     }
 }

--- a/app/src/main/res/menu/btnv_menu.xml
+++ b/app/src/main/res/menu/btnv_menu.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/home"
+        android:id="@+id/HistoryFragment"
         android:icon="@drawable/btnv_history"
         android:title="진단기록"
         android:enabled="true"
@@ -11,7 +11,7 @@
         />
 
     <item
-        android:id="@+id/Search"
+        android:id="@+id/CommunityFragment"
         android:icon="@drawable/btnv_community"
         android:title="커뮤니티"
         app:showAsAction="always"
@@ -23,14 +23,14 @@
         android:enabled="false"/>
 
     <item
-        android:id="@+id/Profile"
+        android:id="@+id/SearchFragment"
         android:icon="@drawable/btnv_search"
         app:showAsAction="always"
         android:title="정보검색"
         android:enabled="true" />
 
     <item
-        android:id="@+id/Settings"
+        android:id="@+id/MyPageFragment"
         android:icon="@drawable/btnv_mypage"
         app:showAsAction="always"
         android:title="마이페이지"


### PR DESCRIPTION
## 개요
- 진단기록 fragment를 작업 중, 화면을 바텀네비게이션에 연결해주고자 바텀네비게이션 아이콘 클릭 이벤트를 구현하였습니다.

## 작업사항
- setBottomNavi() 함수 부분
- 바텀네비게이션 아이콘 클릭 이벤트를 추가하였습니다.

## 주의사항
- 아직 진단기록, 커뮤니티, 정보 검색, 마이페이지의 Fragment가 만들어지지 않아서 아직 모든 아이콘 클릭시 SearchFragment로 이동하게 해두었습니다.
