### PR TITLE
fix: 로그인 오류 수정

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,12 +41,12 @@
             android:name=".presentation.login.LoginActivity"
             android:exported="true">
 
-            <!-- <intent-filter> -->
-            <!-- <action android:name="android.intent.action.MAIN" /> -->
+             <intent-filter>
+             <action android:name="android.intent.action.MAIN" />
 
 
-            <!-- <category android:name="android.intent.category.LAUNCHER" /> -->
-            <!-- </intent-filter> -->
+             <category android:name="android.intent.category.LAUNCHER" />
+             </intent-filter>
         </activity>
         <activity
             android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
@@ -65,11 +65,11 @@
         <activity
             android:name=".presentation.main.MainActivity"
             android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
+<!--            <intent-filter>-->
+<!--                <action android:name="android.intent.action.MAIN" />-->
 
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
+<!--                <category android:name="android.intent.category.LAUNCHER" />-->
+<!--            </intent-filter>-->
         </activity>
         <activity
             android:name=".presentation.diagnosis.DiagnosisResultActivity"

--- a/app/src/main/java/com/konkuk/nongboohae/presentation/base/BaseActivity.kt
+++ b/app/src/main/java/com/konkuk/nongboohae/presentation/base/BaseActivity.kt
@@ -31,11 +31,6 @@ abstract class BaseActivity<T : ViewDataBinding> : AppCompatActivity() {
         startActivity(intent)
     }
 
-    //뷰모델 생성 함수
-    inline fun <reified VM : ViewModel, R> createViewModel(repository: R): VM {
-        val viewModelFactory = ViewModelFactory(repository)
-        return ViewModelProvider(this, viewModelFactory)[VM::class.java]
-    }
 
     abstract fun initViewModel()
     abstract fun afterViewCreated()

--- a/app/src/main/java/com/konkuk/nongboohae/presentation/diagnosis/DiagnosisResultActivity.kt
+++ b/app/src/main/java/com/konkuk/nongboohae/presentation/diagnosis/DiagnosisResultActivity.kt
@@ -3,11 +3,13 @@ package com.konkuk.nongboohae.presentation.diagnosis
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.lifecycle.ViewModelProvider
 import com.konkuk.nongboohae.R
 import com.konkuk.nongboohae.databinding.ActivityDiagnosisResultBinding
 import com.konkuk.nongboohae.presentation.base.BaseActivity
 import com.konkuk.nongboohae.presentation.login.LoginViewModel
 import com.konkuk.nongboohae.presentation.login.MemberRepository
+import com.konkuk.nongboohae.util.factory.ViewModelFactory
 
 class DiagnosisResultActivity : BaseActivity<ActivityDiagnosisResultBinding>() {
     override val TAG: String = "DiagnosisResultActivity"
@@ -15,7 +17,7 @@ class DiagnosisResultActivity : BaseActivity<ActivityDiagnosisResultBinding>() {
     lateinit var viewModel: DiagnosisResultViewModel
 
     override fun initViewModel() {
-        viewModel = createViewModel(DiagnosisRepository())
+        viewModel = ViewModelProvider(this, ViewModelFactory(DiagnosisRepository()))[DiagnosisResultViewModel::class.java]
     }
 
     override fun afterViewCreated() {

--- a/app/src/main/java/com/konkuk/nongboohae/presentation/diagnosis/DiseaseInfoActivity.kt
+++ b/app/src/main/java/com/konkuk/nongboohae/presentation/diagnosis/DiseaseInfoActivity.kt
@@ -2,10 +2,14 @@ package com.konkuk.nongboohae.presentation.diagnosis
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.lifecycle.ViewModelProvider
 import com.konkuk.nongboohae.R
 import com.konkuk.nongboohae.databinding.ActivityDiagnosisResultBinding
 import com.konkuk.nongboohae.databinding.ActivityDiseaseInfoBinding
 import com.konkuk.nongboohae.presentation.base.BaseActivity
+import com.konkuk.nongboohae.presentation.login.LoginViewModel
+import com.konkuk.nongboohae.presentation.login.MemberRepository
+import com.konkuk.nongboohae.util.factory.ViewModelFactory
 
 class DiseaseInfoActivity : BaseActivity<ActivityDiseaseInfoBinding>() {
     override val TAG: String = "DiseaseInfoActivity"
@@ -13,7 +17,7 @@ class DiseaseInfoActivity : BaseActivity<ActivityDiseaseInfoBinding>() {
     lateinit var viewModel: DiseaseInfoViewModel
 
     override fun initViewModel() {
-        viewModel = createViewModel(DiseaseRepository())
+        viewModel = ViewModelProvider(this, ViewModelFactory(DiseaseRepository()))[DiseaseInfoViewModel::class.java]
     }
 
     override fun afterViewCreated() {

--- a/app/src/main/java/com/konkuk/nongboohae/presentation/login/LoginActivity.kt
+++ b/app/src/main/java/com/konkuk/nongboohae/presentation/login/LoginActivity.kt
@@ -1,8 +1,11 @@
 package com.konkuk.nongboohae.presentation.login
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import com.konkuk.nongboohae.R
 import com.konkuk.nongboohae.databinding.ActivityLoginBinding
 import com.konkuk.nongboohae.presentation.base.BaseActivity
+import com.konkuk.nongboohae.util.factory.ViewModelFactory
 
 class LoginActivity : BaseActivity<ActivityLoginBinding>() {
     override val TAG: String = "LoginActivity"
@@ -10,9 +13,8 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>() {
     lateinit var viewModel: LoginViewModel
 
     override fun initViewModel() {
-        viewModel = createViewModel(MemberRepository())
+        viewModel = ViewModelProvider(this, ViewModelFactory(MemberRepository()))[LoginViewModel::class.java]
     }
-
     override fun afterViewCreated() {
 
     }

--- a/app/src/main/java/com/konkuk/nongboohae/presentation/login/LoginFragment.kt
+++ b/app/src/main/java/com/konkuk/nongboohae/presentation/login/LoginFragment.kt
@@ -2,6 +2,7 @@ package com.konkuk.nongboohae.presentation.login
 
 import BaseFragment
 import android.util.Log
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.ClientError
@@ -17,14 +18,12 @@ class LoginFragment : BaseFragment<FragmentLoginBinding>() {
     override val layoutRes: Int
         get() = R.layout.fragment_login
 
-    val viewModel: LoginViewModel by viewModels()
+    val viewModel: LoginViewModel by activityViewModels()
 
     override fun afterViewCreated() {
         binding.kakaoBtn.setOnClickListener {
             onKakaoBtnClicked()
 
-            //나중에 observe필드로 이동 예정
-//            onKakaoLoginSucceed()
         }
     }
 
@@ -40,9 +39,12 @@ class LoginFragment : BaseFragment<FragmentLoginBinding>() {
         if (error != null) {
             Log.e(TAG, "카카오계정으로 로그인 실패", error)
         } else if (token != null) {
-            Log.i(TAG, "카카오계정으로 로그인 성공 ${token.accessToken}")
+            Log.i(TAG, "카카오계정으로 로그인 성공")
             val pair = getUserInfo()
             viewModel.requestLogin(id = pair.first, email = pair.second)
+
+            //나중에 서버요청 observe필드로 이동 예정
+            onKakaoLoginSucceed()
         }
     }
 
@@ -83,9 +85,11 @@ class LoginFragment : BaseFragment<FragmentLoginBinding>() {
 
                 id = user.id.toString()
                 email = user.kakaoAccount?.email.toString()
+
+                Log.d(TAG, "111$id, $email")
             }
         }
-        showToast("카카오 로그인 성공 id: $id, email: $email")
+        Log.d(TAG, "222$id, $email")
         return Pair(id, email)
     }
 }

--- a/app/src/main/java/com/konkuk/nongboohae/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/com/konkuk/nongboohae/presentation/login/LoginViewModel.kt
@@ -3,5 +3,9 @@ package com.konkuk.nongboohae.presentation.login
 import androidx.lifecycle.ViewModel
 
 class LoginViewModel(val memberRepository: MemberRepository) : ViewModel() {
+    fun requestLogin(id: String, email: String) {
+
+    }
+
 
 }


### PR DESCRIPTION
## 개요
- 카카오 로그인 Activity 관련 오류를 수정했습니다

## 작업사항
- 카카오 로그인 이후 사용자의 id를 받아와 MainActivity로 넘어갑니다
- viewmodel 생성 함수 오류로 인해 삭제 후 각 activity에 생성 코드 추가하였습니다

## 주의사항
- kakao Developers의 [해시 키 문서](https://developers.kakao.com/docs/latest/ko/android/getting-started#before-you-begin-add-key-hash)에 따른 해시 키를 설정해야 로그인이 가능합니다.
