### PR TITLE
feat: 질병정보Activity로 정보전달 & style: 질병진단 화면 디자인 수정

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/konkuk/nongboohae/presentation/diagnosis/DiagnosisResultActivity.kt
+++ b/app/src/main/java/com/konkuk/nongboohae/presentation/diagnosis/DiagnosisResultActivity.kt
@@ -1,7 +1,7 @@
 package com.konkuk.nongboohae.presentation.diagnosis
 
 import android.content.Intent
-import android.net.Uri
+import android.util.Log
 import androidx.lifecycle.ViewModelProvider
 import com.bumptech.glide.Glide
 import com.konkuk.nongboohae.R
@@ -43,6 +43,7 @@ class DiagnosisResultActivity : BaseActivity<ActivityDiagnosisResultBinding>() {
         photoUri = intent.getStringExtra("photoUri")!!
         val filePath = intent.getStringExtra("currentPhotoPath")
         plantName = intent.getStringExtra("plantName")!!
+        Log.d("retrofit-plantName", plantName.toString())
         Glide.with(this)
             .load(photoUri)
             .into(binding.diagnosisResultPhotoIv)

--- a/app/src/main/java/com/konkuk/nongboohae/presentation/diagnosis/DiagnosisResultActivity.kt
+++ b/app/src/main/java/com/konkuk/nongboohae/presentation/diagnosis/DiagnosisResultActivity.kt
@@ -57,6 +57,12 @@ class DiagnosisResultActivity : BaseActivity<ActivityDiagnosisResultBinding>() {
             intent.putExtra("diagnosisResultResponse", viewModel.diagnosisResultResponse.value)
             startActivity(intent)
         }
+        binding.moreCvButton.setOnClickListener {
+            val intent = Intent(this, DiseaseInfoActivity::class.java)
+            intent.putExtra("plantName", plantName)
+            intent.putExtra("diagnosisResultResponse", viewModel.diagnosisResultResponse.value)
+            startActivity(intent)
+        }
         binding.diagnosisResultExitIv.setOnClickListener {
             finish()
         }

--- a/app/src/main/java/com/konkuk/nongboohae/presentation/diagnosis/DiagnosisResultActivity.kt
+++ b/app/src/main/java/com/konkuk/nongboohae/presentation/diagnosis/DiagnosisResultActivity.kt
@@ -34,16 +34,8 @@ class DiagnosisResultActivity : BaseActivity<ActivityDiagnosisResultBinding>() {
         viewModel.diagnosisResultResponse.observe(this) {
             binding.diagnosisResultDiseaseTv.text = it.diseaseName
             binding.diagnosisResultEnvContentTv.text = it.condition
-
-            // <br/> 기준으로 나누기 => 문장 앞에 - 삽입, 뒤에 \n 삽입
-            val sentences = it.symptoms.split("<br/>")
-            val formattedText = StringBuilder()
-            for (sentence in sentences) {
-                formattedText.append("- ").append(sentence.trim()).append("\n")
-            }
-            val symptoms = formattedText.toString()
-            binding.diagnosisResultSymptomContentTv.text = symptoms
-
+            binding.diagnosisResultSymptomContentTv.text = it.symptoms
+            binding.diagnosisResultTreatmentContentTv.text = it.preventionMethod
         }
     }
 
@@ -60,11 +52,8 @@ class DiagnosisResultActivity : BaseActivity<ActivityDiagnosisResultBinding>() {
     private fun initClickListener() {
         binding.diagnosisResultDiseaseMoreIv.setOnClickListener {
             val intent = Intent(this, DiseaseInfoActivity::class.java)
-            intent.putExtra("diseaseName", binding.diagnosisResultDiseaseTv.text)
-            intent.putExtra(
-                "imgUrl",
-                "https://www.nongsaro.go.kr/portal/imgView.do?filePath=/npms/photo/sickns2/&fileName=img_3013_0120161027094643027_TMB.jpg"
-            )
+            intent.putExtra("plantName", plantName)
+            intent.putExtra("diagnosisResultResponse", viewModel.diagnosisResultResponse.value)
             startActivity(intent)
         }
         binding.diagnosisResultExitIv.setOnClickListener {

--- a/app/src/main/java/com/konkuk/nongboohae/presentation/diagnosis/DiagnosisResultViewModel.kt
+++ b/app/src/main/java/com/konkuk/nongboohae/presentation/diagnosis/DiagnosisResultViewModel.kt
@@ -24,6 +24,15 @@ class DiagnosisResultViewModel(private val repository: DiagnosisResultRepository
     private val _diagnosisResult = MutableLiveData<DiagnosisResultResponse>()
     val diagnosisResultResponse : LiveData<DiagnosisResultResponse> = _diagnosisResult
 
+    fun formattingString(s: String): String {
+        // <br/> 기준으로 나누기 => 문장 앞에 - 삽입, 뒤에 \n 삽입
+        val sentences = s.split("<br/>")
+        val formattedText = StringBuilder()
+        for (sentence in sentences) {
+            formattedText.append("- ").append(sentence.trim()).append("\n")
+        }
+        return formattedText.toString()
+    }
 
     fun requestDiagnosisResult(filePath: String?, plantName: String) = viewModelScope.launch {
         val response = withContext(Dispatchers.IO) {
@@ -37,7 +46,13 @@ class DiagnosisResultViewModel(private val repository: DiagnosisResultRepository
         response.byState(
             onSuccess = {
                 Log.d("retrofit", "통신 성공")
-                _diagnosisResult.value = it
+                val formattedResponse  =  DiagnosisResultResponse(
+                        it.diseaseName,
+                        formattingString(it.condition),
+                        formattingString(it.symptoms),
+                        formattingString(it.preventionMethod),
+                        it.diseaseImg)
+                _diagnosisResult.value = formattedResponse
                 Log.d("retrofit", it.toString())
             },
             onFailure = {

--- a/app/src/main/java/com/konkuk/nongboohae/presentation/diagnosis/DiseaseInfoActivity.kt
+++ b/app/src/main/java/com/konkuk/nongboohae/presentation/diagnosis/DiseaseInfoActivity.kt
@@ -5,6 +5,7 @@ import com.bumptech.glide.Glide
 import com.konkuk.nongboohae.R
 import com.konkuk.nongboohae.databinding.ActivityDiseaseInfoBinding
 import com.konkuk.nongboohae.presentation.base.BaseActivity
+import com.konkuk.nongboohae.remote.response.DiagnosisResultResponse
 import com.konkuk.nongboohae.util.factory.ViewModelFactory
 
 class DiseaseInfoActivity : BaseActivity<ActivityDiseaseInfoBinding>() {
@@ -22,10 +23,14 @@ class DiseaseInfoActivity : BaseActivity<ActivityDiseaseInfoBinding>() {
     }
 
     private fun initData() {
-        val diseaseName = intent.getStringExtra("diseaseName")
-        val imgUrl = intent.getStringExtra("imgUrl")
-        binding.diseaseInfoDxNameTv.text = diseaseName
-        Glide.with(this).load(imgUrl).into(binding.diseaseInfoPhotoIv)
+        val plantName = intent.getStringExtra("plantName")
+        val diagnosisResultResponse = intent.getSerializableExtra("diagnosisResultResponse") as DiagnosisResultResponse
+        binding.diseaseInfoCropNameTv.text = plantName
+        binding.diseaseInfoDxNameTv.text = diagnosisResultResponse.diseaseName
+        binding.diseaseInfoEnvContentTv.text = diagnosisResultResponse.condition
+        binding.diseaseInfoSymptomContentTv.text = diagnosisResultResponse.symptoms
+        binding.diseaseInfoTreatmentContentTv.text = diagnosisResultResponse.preventionMethod
+        Glide.with(this).load(diagnosisResultResponse.diseaseImg).into(binding.diseaseInfoPhotoIv)
     }
 
     private fun initClickListener() {

--- a/app/src/main/java/com/konkuk/nongboohae/remote/response/DianosisResultResponse.kt
+++ b/app/src/main/java/com/konkuk/nongboohae/remote/response/DianosisResultResponse.kt
@@ -1,9 +1,11 @@
 package com.konkuk.nongboohae.remote.response
 
+import java.io.Serializable
+
 data class DiagnosisResultResponse(
     val diseaseName:String,
     val condition: String,
     val symptoms: String,
     val preventionMethod: String,
     val diseaseImg: String
-)
+) : Serializable

--- a/app/src/main/res/drawable/bg_gradient.xml
+++ b/app/src/main/res/drawable/bg_gradient.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <gradient
+        android:angle="90"
+        android:endColor="#00FFFFFF"
+        android:startColor="#FFFFFFFF"
+        android:type="linear" />
+</shape>

--- a/app/src/main/res/layout/activity_diagnosis_result.xml
+++ b/app/src/main/res/layout/activity_diagnosis_result.xml
@@ -81,123 +81,176 @@
                 android:layout_height="match_parent"
                 android:background="@drawable/black_round">
 
-                <ImageView
-                    android:id="@+id/diagnosis_result_photo_iv"
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/diagnosis_result_photo_cv"
                     android:layout_width="match_parent"
-                    android:layout_height="230dp"
-                    android:scaleType="centerCrop"
+                    android:layout_height="240dp"
                     app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    android:src="@color/cardview_shadow_start_color" />
+                    app:cardElevation="0dp"
+                    app:cardCornerRadius="10dp"
+                    android:layout_margin="1dp">
 
-                <TextView
-                    android:id="@+id/diagnosis_result_disease_tv"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:textColor="@color/darkgray"
-                    android:textSize="20sp"
-                    android:textStyle="bold"
-                    android:layout_marginStart="30dp"
-                    android:layout_marginTop="20dp"
+                    <ImageView
+                        android:layout_margin="0.1dp"
+                        android:id="@+id/diagnosis_result_photo_iv"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:scaleType="centerCrop"
+                        android:src="@color/cardview_shadow_start_color" />
+                </androidx.cardview.widget.CardView>
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/card_content_layout"
+                    android:layout_width="match_parent"
+                    android:layout_height="0dp"
+                    app:layout_constraintTop_toBottomOf="@id/diagnosis_result_photo_cv"
+                    app:layout_constraintBottom_toTopOf="@id/more_cv_button"
+                    android:layout_marginBottom="20dp"
+                    android:layout_marginTop="-10dp"
+                    android:background="@color/white"
+                    android:layout_marginHorizontal="1dp"
+                    >
+
+                    <TextView
+                        android:id="@+id/diagnosis_result_disease_tv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/darkgray"
+                        android:text="   "
+                        android:textSize="18sp"
+                        android:textStyle="bold"
+                        android:layout_marginStart="30dp"
+                        android:layout_marginTop="20dp"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"/>
+
+                    <ImageView
+                        android:id="@+id/diagnosis_result_disease_more_iv"
+                        android:layout_width="30dp"
+                        android:layout_height="30dp"
+                        android:padding="10dp"
+                        android:src="@drawable/ic_right_arrow"
+                        app:layout_constraintStart_toEndOf="@id/diagnosis_result_disease_tv"
+                        app:layout_constraintTop_toTopOf="@id/diagnosis_result_disease_tv"
+                        app:layout_constraintBottom_toBottomOf="@id/diagnosis_result_disease_tv"
+                        android:layout_marginStart="-4dp"
+                        android:layout_marginTop="2dp" />
+
+                    <TextView
+                        android:id="@+id/diagnosis_result_env_title_tv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="발생환경"
+                        android:textColor="@color/green2"
+                        android:textSize="15sp"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/diagnosis_result_disease_tv"
+                        android:layout_marginStart="30dp"
+                        android:layout_marginTop="25dp"/>
+
+                    <TextView
+                        android:id="@+id/diagnosis_result_env_content_tv"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:maxLines="2"
+                        android:ellipsize="end"
+                        android:textColor="@color/darkgray"
+                        android:textSize="15sp"
+                        app:layout_constraintStart_toStartOf="@id/diagnosis_result_env_title_tv"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/diagnosis_result_env_title_tv"
+                        android:layout_marginTop="10dp"
+                        android:layout_marginEnd="30dp"/>
+
+                    <TextView
+                        android:id="@+id/diagnosis_result_symptom_title_tv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="증상설명"
+                        android:textColor="@color/green2"
+                        android:textSize="15sp"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/diagnosis_result_env_content_tv"
+                        android:layout_marginStart="30dp"
+                        android:layout_marginTop="23dp"/>
+
+                    <TextView
+                        android:id="@+id/diagnosis_result_symptom_content_tv"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/darkgray"
+                        android:textSize="15sp"
+                        android:maxLines="2"
+                        android:ellipsize="end"
+                        app:layout_constraintStart_toStartOf="@id/diagnosis_result_symptom_title_tv"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/diagnosis_result_symptom_title_tv"
+                        android:layout_marginTop="10dp"
+                        android:layout_marginEnd="30dp"/>
+
+                    <TextView
+                        android:id="@+id/diagnosis_result_treatment_title_tv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="방제방법"
+                        android:textColor="@color/green2"
+                        android:textSize="15sp"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/diagnosis_result_symptom_content_tv"
+                        android:layout_marginStart="30dp"
+                        android:layout_marginTop="23dp"/>
+
+                    <TextView
+                        android:id="@+id/diagnosis_result_treatment_content_tv"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/darkgray"
+                        android:textSize="15sp"
+                        android:ellipsize="end"
+                        app:layout_constraintStart_toStartOf="@id/diagnosis_result_treatment_title_tv"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/diagnosis_result_treatment_title_tv"
+                        android:layout_marginTop="10dp"
+                        android:layout_marginEnd="30dp"
+                        android:layout_marginBottom="30dp"/>
+
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+                
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="60dp"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/diagnosis_result_photo_iv"/>
-
-                <ImageView
-                    android:id="@+id/diagnosis_result_disease_more_iv"
-                    android:layout_width="35dp"
-                    android:layout_height="35dp"
-                    android:padding="10dp"
-                    android:src="@drawable/ic_right_arrow"
-                    app:layout_constraintStart_toEndOf="@id/diagnosis_result_disease_tv"
-                    app:layout_constraintTop_toTopOf="@id/diagnosis_result_disease_tv"
-                    app:layout_constraintBottom_toBottomOf="@id/diagnosis_result_disease_tv"
-                    android:layout_marginStart="-4dp"
-                    android:layout_marginTop="2dp" />
-
-                <TextView
-                    android:id="@+id/diagnosis_result_env_title_tv"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="발생환경"
-                    android:textColor="@color/green2"
-                    android:textSize="15sp"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/diagnosis_result_disease_tv"
-                    android:layout_marginStart="30dp"
-                    android:layout_marginTop="25dp"/>
-
-                <TextView
-                    android:id="@+id/diagnosis_result_env_content_tv"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:maxLines="2"
-                    android:ellipsize="end"
-                    android:textColor="@color/darkgray"
-                    android:textSize="15sp"
-                    app:layout_constraintStart_toStartOf="@id/diagnosis_result_env_title_tv"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/diagnosis_result_env_title_tv"
-                    android:layout_marginTop="10dp"
-                    android:layout_marginEnd="30dp"/>
+                    app:layout_constraintBottom_toBottomOf="@id/card_content_layout"
+                    android:background="@drawable/bg_gradient"
+                    android:layout_marginHorizontal="2dp"/>
 
-                <TextView
-                    android:id="@+id/diagnosis_result_symptom_title_tv"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="증상설명"
-                    android:textColor="@color/green2"
-                    android:textSize="15sp"
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/more_cv_button"
+                    android:layout_width="130dp"
+                    android:layout_height="30dp"
+                    app:cardCornerRadius="10dp"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/diagnosis_result_env_content_tv"
-                    android:layout_marginStart="30dp"
-                    android:layout_marginTop="23dp"/>
-
-                <TextView
-                    android:id="@+id/diagnosis_result_symptom_content_tv"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:textColor="@color/darkgray"
-                    android:textSize="15sp"
-                    android:maxLines="2"
-                    android:ellipsize="end"
-                    app:layout_constraintStart_toStartOf="@id/diagnosis_result_symptom_title_tv"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/diagnosis_result_symptom_title_tv"
-                    android:layout_marginTop="10dp"
-                    android:layout_marginEnd="30dp"/>
-
-                <TextView
-                    android:id="@+id/diagnosis_result_treatment_title_tv"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="방제방법"
-                    android:textColor="@color/green2"
-                    android:textSize="15sp"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/diagnosis_result_symptom_content_tv"
-                    android:layout_marginStart="30dp"
-                    android:layout_marginTop="23dp"/>
-
-                <TextView
-                    android:id="@+id/diagnosis_result_treatment_content_tv"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:textColor="@color/darkgray"
-                    android:textSize="15sp"
-                    android:ellipsize="end"
-                    app:layout_constraintStart_toStartOf="@id/diagnosis_result_treatment_title_tv"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/diagnosis_result_treatment_title_tv"
-                    android:layout_marginTop="10dp"
-                    android:layout_marginEnd="30dp"
-                    android:layout_marginBottom="30dp"/>
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    android:layout_marginBottom="30dp"
+                    android:backgroundTint="@color/green2">
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:textColor="@color/white"
+                        android:textAlignment="center"
+                        android:gravity="center"
+                        android:text="더 알아보기"/>
+                </androidx.cardview.widget.CardView>
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
-
-
         </androidx.cardview.widget.CardView>
+
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
## 개요
- 진단결과 Activity에서 질병정보 Activity로 서버에서 받은 질병 정보를 전달합니다. (intent이용)
- 질병진단 화면 디자인 수정하였습니다.

## 작업사항
- 아래에 더 알아보기 버튼을 추가하였습니다
- 더 알아보기 버튼이나 병명 옆의 더보기 버튼을 누르면 질병정보 화면으로 이동합니다.
- 글자 잘리는 걸 자연스럽게 하기 위해 그라데이션 효과를 넣었습니다.

## 주의사항
- 아직 정상에 대한 디자인은 따로 처리하지 않았습니다.
